### PR TITLE
ignore node types

### DIFF
--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -8,5 +8,6 @@
         "e2etest/package.json"
       ]
     }
-  }
+  },
+  "ignore": ["@types/node"]
 }


### PR DESCRIPTION
need version 10 and greenkeer does currently not support to use an older major version

closes #60 