### PR TITLE
use buildkit v6

### DIFF
--- a/node/startbuildkitd.sh
+++ b/node/startbuildkitd.sh
@@ -2,6 +2,6 @@
 set -e
 
 docker rm --force buildkit || true
-docker run -d --privileged -p 1234:1234 --name buildkit moby/buildkit:latest  --addr tcp://0.0.0.0:1234  --oci-worker-platform linux/arm/v6
+docker run -d --privileged -p 1234:1234 --name buildkit moby/buildkit:v0.6.4  --addr tcp://0.0.0.0:1234  --oci-worker-platform linux/arm/v6
 sudo docker cp buildkit:/usr/bin/buildctl /usr/bin/
 export BUILDKIT_HOST=tcp://0.0.0.0:1234


### PR DESCRIPTION
Pin to prevent docker build errors
failed to solve: rpc error: code = Unknown desc = failed to load cache: failed to copy: httpReaderSeeker: failed open: server message: invalid_token: authorization failed